### PR TITLE
Subscribe handlers immediately if connected.

### DIFF
--- a/lib/ptt.rb
+++ b/lib/ptt.rb
@@ -17,7 +17,7 @@ module PTT
     client.connect
 
     handlers.each do |(routing_key, handler)|
-      consumers[routing_key].subscribe(handler)
+      subscribe(routing_key, handler)
     end
   end
 
@@ -27,6 +27,8 @@ module PTT
 
   def register_handler(routing_key, handler)
     handlers[routing_key] = handler
+
+    subscribe(routing_key, handler) if client.connected?
   end
 
   def handler_for(routing_key)
@@ -54,6 +56,10 @@ module PTT
         client.queue_for(routing_key)
       )
     end
+  end
+
+  def subscribe(routing_key, handler)
+    consumers[routing_key].subscribe(handler)
   end
 
   def handlers

--- a/lib/ptt/amqp_client.rb
+++ b/lib/ptt/amqp_client.rb
@@ -11,6 +11,10 @@ module PTT
 
     class ConnectionError < Error; end
 
+    def connected?
+      @connection && @connection.open?
+    end
+
     def connect
       connection.start
     rescue Bunny::TCPConnectionFailed => exception
@@ -18,7 +22,7 @@ module PTT
     end
 
     def disconnect
-      if connection && connection.open?
+      if connected?
         connection.close
         @connection = nil
       end

--- a/lib/ptt/null_client.rb
+++ b/lib/ptt/null_client.rb
@@ -16,10 +16,16 @@ module PTT
   #     ptt.client = PTT::NullClient.new
   #   end
   class NullClient
+    def connected?
+      @connected
+    end
+
     def connect
+      @connected = true
     end
 
     def disconnect
+      @connected = false
     end
 
     def channel


### PR DESCRIPTION
Hi @soulim! Here is a little contribution to your excellent library :smile:

This PR is intended to allow that `PTT.connect` may be called before `PTT.register_handler`. This allows a little bit more flexibility with application configuration, as you will soon see in another PR :wink:

Let me know if there's anything you'd like added or changed.