### PR TITLE
Get rid of a deprecation warning of Bunny gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ class Handler
   end
 end
 
-# In this case `Handler#call` will be called each time when a new messages comes
+# In this case `Handler#call` will be called each time when a new message comes
 # from RabbitMQ with routing key `foo`
 PTT.configure do |pneumatic_tube|
   pneumatic_tube.register_handler('foo', Handler.new)

--- a/lib/ptt/consumer.rb
+++ b/lib/ptt/consumer.rb
@@ -9,11 +9,9 @@ module PTT
 
     def subscribe(handler)
       @handler = handler
-      @queue.subscribe(ack: true, &method(:receive))
+      @queue.subscribe(manual_ack: true, &method(:receive))
     end
 
-    # FIXME Fix deprecation:
-    #       `:ack` is deprecated. Please use `:manual_ack` instead.
     def receive(delivery_info, properties, body)
       @handler.call(JSON.parse(body))
       @channel.ack(delivery_info.delivery_tag)


### PR DESCRIPTION
When consumers subscribe, they should use a `manual_ack` option instead of `ack` to acknowledge a failure.

The warning has been coming from [this line](https://github.com/ruby-amqp/bunny/blob/2d414fc6f7f29707a505c78263adf5601f8e018a/lib/bunny/queue.rb#L177). :smile_cat: 