### PR TITLE
Requeue rejected messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ PTT - messaging based on RabbitMQ and some conventions. It's built on top of [Bu
 - Messages are JSON-encoded strings
 - Consumers decode JSON payload and call message handlers
 - Publisher uses **just** direct AMQP exchange (however it might change later)
+- By default rejected messages are not requeued. This behviour can be changed by setting `ENV[REQUEUE_REJECTED_MESSAGE']='true'`
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ PTT - messaging based on RabbitMQ and some conventions. It's built on top of [Bu
 - Messages are JSON-encoded strings
 - Consumers decode JSON payload and call message handlers
 - Publisher uses **just** direct AMQP exchange (however it might change later)
-- By default rejected messages are not requeued. This behviour can be changed by setting `ENV[REQUEUE_REJECTED_MESSAGE']='true'`
+- By default rejected messages are not requeued.
 
 ## Installation
 
@@ -57,6 +57,39 @@ data = { foo: 'bar' }
 
 # JSON encoded data will be send to exchange with `bar` routing key
 PTT.publish('bar', data)
+```
+
+In case you need to requeue rejected messages there are two option available:
+
+ - Via environment variable: `PTT_REQUEUE_REJECTED_MESSAGE=true`.
+This will override the default requeu value for the whole project.
+
+ - Per handler, example:
+
+```ruby
+class CarefulHandler
+  def call(json)
+    # do some work
+  end
+
+  def  requeue?
+    # computes result based on internal state or logic,
+    # e.g. requeue on specific exceptions, but do not
+    # requeue in other cases.
+  end
+end
+
+class CarelessHandler
+  def call(json)
+    # do some work
+  end
+
+  def  requeue?
+    # in case of any failure simply drop messages from
+    # the queue and don't even try anything else.
+    return false
+  end
+end
 ```
 
 ## Testing

--- a/lib/ptt/consumer.rb
+++ b/lib/ptt/consumer.rb
@@ -5,7 +5,6 @@ module PTT
     def initialize(channel, queue)
       @channel = channel
       @queue = queue
-      @requeue = ENV['REQUEUE_REJECTED_MESSAGE'] == 'true' ? true : false
     end
 
     def subscribe(handler)
@@ -17,7 +16,17 @@ module PTT
       @handler.call(JSON.parse(body))
       @channel.ack(delivery_info.delivery_tag)
     rescue => e
-      @channel.reject(delivery_info.delivery_tag, @requeue)
+      @channel.reject(delivery_info.delivery_tag, requeue)
+    end
+
+    private
+
+    def requeue
+      if @handler.respond_to?(:requeue?)
+        @handler.requeue?
+      else
+        ENV['PTT_REQUEUE_REJECTED_MESSAGE'] == 'true' ? true : false
+      end
     end
   end
 end

--- a/lib/ptt/consumer.rb
+++ b/lib/ptt/consumer.rb
@@ -5,6 +5,7 @@ module PTT
     def initialize(channel, queue)
       @channel = channel
       @queue = queue
+      @requeue = ENV['REQUEUE_REJECTED_MESSAGE'] == 'true' ? true : false
     end
 
     def subscribe(handler)
@@ -16,7 +17,7 @@ module PTT
       @handler.call(JSON.parse(body))
       @channel.ack(delivery_info.delivery_tag)
     rescue => e
-      @channel.reject(delivery_info.delivery_tag, false)
+      @channel.reject(delivery_info.delivery_tag, @requeue)
     end
   end
 end

--- a/spec/ptt/consumer_spec.rb
+++ b/spec/ptt/consumer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PTT::Consumer do
   let(:requeue_rejected) { nil }
 
   before do
-    ENV['REQUEUE_REJECTED_MESSAGE'] = requeue_rejected
+    ENV['PTT_REQUEUE_REJECTED_MESSAGE'] = requeue_rejected
     allow(queue).to receive(:subscribe)
   end
 
@@ -56,6 +56,18 @@ RSpec.describe PTT::Consumer do
           false
         )
         subject.receive(delivery_info, properties, body)
+      end
+
+      context 'and handler is set to requeu messages' do
+        let(:handler) { double(:call, requeue?: true) }
+
+        it 'should reject the message and add it back to the queue' do
+          expect(channel).to receive(:reject).with(
+            delivery_info.delivery_tag,
+            true
+          )
+          subject.receive(delivery_info, properties, body)
+        end
       end
 
       context 'and requeue ENV variable is set to true' do


### PR DESCRIPTION
Right now all the rejected messages are dropped from the message queue. These changes will allow configuring the gem to perform requeuing on message rejection. 

Another option could be to configure the requeuing per handler instead of using a global value. What are your thoughts about these @soulim ?